### PR TITLE
Update ollama to latest version

### DIFF
--- a/com.jeffser.Alpaca.json
+++ b/com.jeffser.Alpaca.json
@@ -94,8 +94,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://github.com/ollama/ollama/releases/download/v0.1.39/ollama-linux-amd64",
-                    "sha256": "4d19be355842a6297c93ab5ada139fe396126736bf3c3882a879dc245dffe3af",
+                    "url": "https://github.com/ollama/ollama/releases/download/v0.2.1/ollama-linux-amd64",
+                    "sha256": "8a29a80403f67abe0f5b3737767b2a21732409e8e4429098af75474484e43c18",
                     "only-arches": [
                         "x86_64"
                     ],
@@ -109,8 +109,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://github.com/ollama/ollama/releases/download/v0.1.39/ollama-linux-arm64",
-                    "sha256": "60ec2d36928c11d6c6d84fe91451308a46aafaedbdba44664e5a6080009ce097",
+                    "url": "https://github.com/ollama/ollama/releases/download/v0.2.1/ollama-linux-arm64",
+                    "sha256": "6a9080c6f857db9293817845b20a9e35c5e55cef944da6af0abbb6f2f8afb22d",
                     "only-arches": [
                         "aarch64"
                     ],

--- a/com.jeffser.Alpaca.json
+++ b/com.jeffser.Alpaca.json
@@ -1,126 +1,126 @@
 {
-	"id": "com.jeffser.Alpaca",
-	"runtime": "org.gnome.Platform",
-	"runtime-version": "46",
-	"sdk": "org.gnome.Sdk",
-	"command": "alpaca",
-	"finish-args": [
-		"--share=network",
-		"--share=ipc",
-		"--socket=fallback-x11",
-		"--device=dri",
-		"--socket=wayland"
-	],
-	"cleanup": [
-		"/include",
-		"/lib/pkgconfig",
-		"/man",
-		"/share/doc",
-		"/share/gtk-doc",
-		"/share/man",
-		"/share/pkgconfig",
-		"*.la",
-		"*.a"
-	],
-	"modules": [
-		{
-			"name": "python3-requests",
-			"buildsystem": "simple",
-			"build-commands": [
-				"pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests\" --no-build-isolation"
-			],
-			"sources": [
-				{
-					"type": "file",
-					"url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
-					"sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
-				},
-				{
-					"type": "file",
-					"url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
-					"sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
-				},
-				{
-					"type": "file",
-					"url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
-					"sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
-				},
-				{
-					"type": "file",
-					"url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
-					"sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
-				},
-				{
-					"type": "file",
-					"url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
-					"sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
-				}
-			]
-		},
-		{
-			"name": "python3-pillow",
-			"buildsystem": "simple",
-			"build-commands": [
-				"pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
-			],
-			"sources": [
-				{
-					"type": "file",
-					"url": "https://files.pythonhosted.org/packages/ef/43/c50c17c5f7d438e836c169e343695534c38c77f60e7c90389bd77981bc21/pillow-10.3.0.tar.gz",
-					"sha256": "9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d"
-				}
-			]
-		},
-		{
-		    "name": "python3-pypdf",
-		    "buildsystem": "simple",
-		    "build-commands": [
-			"pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pypdf\" --no-build-isolation"
-		    ],
-		    "sources": [
-			{
-			    "type": "file",
-			    "url": "https://files.pythonhosted.org/packages/c9/d1/450b19bbdbb2c802f554312c62ce2a2c0d8744fe14735bc70ad2803578c7/pypdf-4.2.0-py3-none-any.whl",
-			    "sha256": "dc035581664e0ad717e3492acebc1a5fc23dba759e788e3d4a9fc9b1a32e72c1"
-			}
-		    ]
-		},
-	        {
-	            "name": "ollama",
-	            "buildsystem": "simple",
-	            "build-commands": [
-			"install -Dm0755 ollama* ${FLATPAK_DEST}/bin/ollama"
-	            ],
-	            "sources": [
-	            	{
-	            		"type": "file",
-	            		"url": "https://github.com/ollama/ollama/releases/download/v0.1.39/ollama-linux-amd64",
-	            		"sha256": "4d19be355842a6297c93ab5ada139fe396126736bf3c3882a879dc245dffe3af",
-			    	"only-arches": [
-			    		"x86_64"
-			    	]
-	            	},
-	            	{
-	            		"type": "file",
-	            		"url": "https://github.com/ollama/ollama/releases/download/v0.1.39/ollama-linux-arm64",
-	            		"sha256": "60ec2d36928c11d6c6d84fe91451308a46aafaedbdba44664e5a6080009ce097",
-			    	"only-arches": [
-			    		"aarch64"
-			    	]
-	            	}
-	            ]
-	        },
-		{
-			"name": "alpaca",
-			"builddir": true,
-			"buildsystem": "meson",
-			"sources": [
-				{
-					"type": "git",
-					"url": "https://github.com/Jeffser/Alpaca.git",
-					"tag": "0.9.6.1"
-				}
-			]
-		}
-	]
+    "id": "com.jeffser.Alpaca",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "46",
+    "sdk": "org.gnome.Sdk",
+    "command": "alpaca",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "python3-requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
+                    "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
+                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
+                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
+                    "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
+                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
+                }
+            ]
+        },
+        {
+            "name": "python3-pillow",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ef/43/c50c17c5f7d438e836c169e343695534c38c77f60e7c90389bd77981bc21/pillow-10.3.0.tar.gz",
+                    "sha256": "9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d"
+                }
+            ]
+        },
+        {
+            "name": "python3-pypdf",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pypdf\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/c9/d1/450b19bbdbb2c802f554312c62ce2a2c0d8744fe14735bc70ad2803578c7/pypdf-4.2.0-py3-none-any.whl",
+                    "sha256": "dc035581664e0ad717e3492acebc1a5fc23dba759e788e3d4a9fc9b1a32e72c1"
+                }
+            ]
+        },
+        {
+            "name": "ollama",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm0755 ollama* ${FLATPAK_DEST}/bin/ollama"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://github.com/ollama/ollama/releases/download/v0.1.39/ollama-linux-amd64",
+                    "sha256": "4d19be355842a6297c93ab5ada139fe396126736bf3c3882a879dc245dffe3af",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/ollama/ollama/releases/download/v0.1.39/ollama-linux-arm64",
+                    "sha256": "60ec2d36928c11d6c6d84fe91451308a46aafaedbdba44664e5a6080009ce097",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "alpaca",
+            "builddir": true,
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Jeffser/Alpaca.git",
+                    "tag": "0.9.6.1"
+                }
+            ]
+        }
+    ]
 }

--- a/com.jeffser.Alpaca.json
+++ b/com.jeffser.Alpaca.json
@@ -98,7 +98,14 @@
                     "sha256": "4d19be355842a6297c93ab5ada139fe396126736bf3c3882a879dc245dffe3af",
                     "only-arches": [
                         "x86_64"
-                    ]
+                    ],
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/ollama/ollama/releases/latest",
+                        "timestamp-query": ".published_at",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"ollama-linux-amd64\") | .browser_download_url"
+                    }
                 },
                 {
                     "type": "file",
@@ -106,7 +113,14 @@
                     "sha256": "60ec2d36928c11d6c6d84fe91451308a46aafaedbdba44664e5a6080009ce097",
                     "only-arches": [
                         "aarch64"
-                    ]
+                    ],
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/ollama/ollama/releases/latest",
+                        "timestamp-query": ".published_at",
+                        "version-query": ".tag_name | sub(\"^v\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"ollama-linux-arm64\") | .browser_download_url"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
This PR is for updating the ollama module to the latest version and I also added the configuration so that for each new versions of ollama, flathubbot will create an new PR here automatically.
For more information refer to [flatpak-external-data-checker](https://github.com/flathub-infra/flatpak-external-data-checker/).

Every time flatpak-external-data-checker creates a commit, all the JSON is linted to their format, so here I pre-linted in a separated commit  so you can validate better the changes, so the first commit only lints without performing any change.

Please tell me if you prefer to only update the module without configuring the flatpak-external-data-checker.

Also if you want I can also add the flatpak-external-data-checker to the Alpaca module, so that any new release will automatically create a PR here and start the test build, but since any change in the dependencies will not get automatically updated I don't think it would be as useful.

